### PR TITLE
Added venv with just requests installed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.idea
+venv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+certifi==2023.7.22
+charset-normalizer==3.3.0
+idna==3.4
+requests==2.31.0
+urllib3==2.0.7


### PR DESCRIPTION
Created a virtual environment for the backend folks to use. Currently it only has requests module for API usage installed. requirements.txt should be only object pushed relating to the virtual environment. .gitignore updates as well to exclude venv folder.